### PR TITLE
Pull out marks-pane src files

### DIFF
--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -3,7 +3,7 @@ import {extend, borders, uuid, isNumber, bounds, defer, createBlobUrl, revokeBlo
 import EpubCFI from "../../epubcfi";
 import Contents from "../../contents";
 import { EVENTS } from "../../utils/constants";
-import { Pane, Highlight, Underline } from "marks-pane";
+import { Pane, Highlight, Underline } from "../../utils/marks/marks";
 
 class IframeView {
 	constructor(section, options) {

--- a/src/utils/marks/events.js
+++ b/src/utils/marks/events.js
@@ -1,0 +1,124 @@
+// import 'babelify/polyfill'; // needed for Object.assign
+
+export default {
+    proxyMouse: proxyMouse
+};
+
+
+/**
+ * Start proxying all mouse events that occur on the target node to each node in
+ * a set of tracked nodes.
+ *
+ * The items in tracked do not strictly have to be DOM Nodes, but they do have
+ * to have dispatchEvent, getBoundingClientRect, and getClientRects methods.
+ *
+ * @param target {Node} The node on which to listen for mouse events.
+ * @param tracked {Node[]} A (possibly mutable) array of nodes to which to proxy
+ *                         events.
+ */
+export function proxyMouse(target, tracked) {
+    function dispatch(e) {
+        // We walk through the set of tracked elements in reverse order so that
+        // events are sent to those most recently added first.
+        //
+        // This is the least surprising behaviour as it simulates the way the
+        // browser would work if items added later were drawn "on top of"
+        // earlier ones.
+        for (var i = tracked.length - 1; i >= 0; i--) {
+            var t = tracked[i];
+            var x = e.clientX
+            var y = e.clientY;
+
+            if (e.touches && e.touches.length) {
+              x = e.touches[0].clientX;
+              y = e.touches[0].clientY;
+            }
+
+            if (!contains(t, target, x, y)) {
+                continue;
+            }
+
+            // The event targets this mark, so dispatch a cloned event:
+            t.dispatchEvent(clone(e));
+            // We only dispatch the cloned event to the first matching mark.
+            break;
+        }
+    }
+
+    if (target.nodeName === "iframe" || target.nodeName === "IFRAME") {
+
+      try {
+        // Try to get the contents if same domain
+        this.target = target.contentDocument;
+      } catch(err){
+        this.target = target;
+      }
+
+    } else {
+      this.target = target;
+    }
+
+    for (var ev of ['mouseup', 'mousedown', 'click', 'touchstart']) {
+        this.target.addEventListener(ev, (e) => dispatch(e), false);
+    }
+
+}
+
+
+/**
+ * Clone a mouse event object.
+ *
+ * @param e {MouseEvent} A mouse event object to clone.
+ * @returns {MouseEvent}
+ */
+export function clone(e) {
+    var opts = Object.assign({}, e, {bubbles: false});
+    try {
+        return new MouseEvent(e.type, opts);
+    } catch(err) { // compat: webkit
+        var copy = document.createEvent('MouseEvents');
+        copy.initMouseEvent(e.type, false, opts.cancelable, opts.view,
+                            opts.detail, opts.screenX, opts.screenY,
+                            opts.clientX, opts.clientY, opts.ctrlKey,
+                            opts.altKey, opts.shiftKey, opts.metaKey,
+                            opts.button, opts.relatedTarget);
+        return copy;
+    }
+}
+
+
+/**
+ * Check if the item contains the point denoted by the passed coordinates
+ * @param item {Object} An object with getBoundingClientRect and getClientRects
+ *                      methods.
+ * @param x {Number}
+ * @param y {Number}
+ * @returns {Boolean}
+ */
+function contains(item, target, x, y) {
+    // offset
+    var offset = target.getBoundingClientRect();
+
+    function rectContains(r, x, y) {
+        var top = r.top - offset.top;
+        var left = r.left - offset.left;
+        var bottom = top + r.height;
+        var right = left + r.width;
+        return (top <= y && left <= x && bottom > y && right > x);
+    }
+
+    // Check overall bounding box first
+    var rect = item.getBoundingClientRect();
+    if (!rectContains(rect, x, y)) {
+        return false;
+    }
+
+    // Then continue to check each child rect
+    var rects = item.getClientRects();
+    for (var i = 0, len = rects.length; i < len; i++) {
+        if (rectContains(rects[i], x, y)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/utils/marks/marks.js
+++ b/src/utils/marks/marks.js
@@ -1,0 +1,229 @@
+import svg from './svg';
+import events from './events';
+
+export class Pane {
+    constructor(target, container = document.body) {
+        this.target = target;
+        this.element = svg.createElement('svg');
+        this.marks = [];
+
+        // Match the coordinates of the target element
+        this.element.style.position = 'absolute';
+        // Disable pointer events
+        this.element.setAttribute('pointer-events', 'none');
+
+        // Set up mouse event proxying between the target element and the marks
+        events.proxyMouse(this.target, this.marks);
+
+        this.container = container;
+        this.container.appendChild(this.element);
+
+        this.render();
+    }
+
+    addMark(mark) {
+        var g = svg.createElement('g');
+        this.element.appendChild(g);
+        mark.bind(g, this.container);
+
+        this.marks.push(mark);
+
+        mark.render();
+        return mark;
+    }
+
+    removeMark(mark) {
+        var idx = this.marks.indexOf(mark);
+        if (idx === -1) {
+            return;
+        }
+        var el = mark.unbind();
+        this.element.removeChild(el);
+        this.marks.splice(idx, 1);
+    }
+
+    render() {
+        setCoords(this.element, coords(this.target, this.container));
+        for (var m of this.marks) {
+            m.render();
+        }
+    }
+}
+
+
+export class Mark {
+    constructor() {
+        this.element = null;
+    }
+
+    bind(element, container) {
+        this.element = element;
+        this.container = container;
+    }
+
+    unbind() {
+        var el = this.element;
+        this.element = null;
+        return el;
+    }
+
+    render() {}
+
+    dispatchEvent(e) {
+        if (!this.element) return;
+        this.element.dispatchEvent(e);
+    }
+
+    getBoundingClientRect() {
+        return this.element.getBoundingClientRect();
+    }
+
+    getClientRects() {
+        var rects = [];
+        var el = this.element.firstChild;
+        while (el) {
+            rects.push(el.getBoundingClientRect());
+            el = el.nextSibling;
+        }
+        return rects;
+    }
+
+    filteredRanges() {
+      var rects = Array.from(this.range.getClientRects());
+
+      let filteredRects = [];
+      for (let i = 0; i < rects.length; i++) {
+          const curRect = rects[i];
+          let shouldPush = true;
+          for (let j = 0; j < rects.length; j++) {
+              if (curRect !== rects[j] && contains(curRect, rects[j])) {
+                  shouldPush = false;
+                  break;
+              }
+          }
+          if (shouldPush) {
+              filteredRects.push(curRect);
+          }
+      }
+
+      return filteredRects;
+    }
+}
+
+export class Highlight extends Mark {
+    constructor(range, className, data, attributes) {
+        super();
+        this.range = range;
+        this.className = className;
+        this.data = data || {};
+        this.attributes = attributes || {};
+    }
+
+    bind(element, container) {
+        super.bind(element, container);
+
+        for (var attr in this.data) {
+          if (this.data.hasOwnProperty(attr)) {
+            this.element.dataset[attr] = this.data[attr];
+          }
+        }
+
+        for (var attr in this.attributes) {
+          if (this.attributes.hasOwnProperty(attr)) {
+            this.element.setAttribute(attr, this.attributes[attr]);
+          }
+        }
+
+        if (this.className) {
+          this.element.classList.add(this.className);
+        }
+    }
+
+    render() {
+        // Empty element
+        while (this.element.firstChild) {
+            this.element.removeChild(this.element.firstChild);
+        }
+
+        var docFrag = this.element.ownerDocument.createDocumentFragment();
+        var filtered = this.filteredRanges();
+        var offset = this.element.getBoundingClientRect();
+        var container = this.container.getBoundingClientRect();
+
+        for (var i = 0, len = filtered.length; i < len; i++) {
+            var r = filtered[i];
+            var el = svg.createElement('rect');
+            el.setAttribute('x', r.left - offset.left + container.left);
+            el.setAttribute('y', r.top - offset.top + container.top);
+            el.setAttribute('height', r.height);
+            el.setAttribute('width', r.width);
+            docFrag.appendChild(el);
+        }
+
+        this.element.appendChild(docFrag);
+
+    }
+}
+
+export class Underline extends Highlight {
+    constructor(range, className, data, attributes) {
+        super(range, className, data,  attributes);
+    }
+
+    render() {
+        // Empty element
+        while (this.element.firstChild) {
+            this.element.removeChild(this.element.firstChild);
+        }
+
+        var docFrag = this.element.ownerDocument.createDocumentFragment();
+        var filtered = this.filteredRanges();
+        var offset = this.element.getBoundingClientRect();
+        var container = this.container.getBoundingClientRect();
+
+        for (var i = 0, len = filtered.length; i < len; i++) {
+            var r = filtered[i];
+
+            var line = svg.createElement('line');
+            line.setAttribute('x1', r.left - offset.left + container.left);
+            line.setAttribute('x2', r.left - offset.left + container.left + r.width);
+            line.setAttribute('y1', r.top - offset.top + container.top + r.height - 1);
+            line.setAttribute('y2', r.top - offset.top + container.top + r.height - 1);
+
+            docFrag.appendChild(line);
+        }
+
+        this.element.appendChild(docFrag);
+
+    }
+}
+
+
+function coords(el, container) {
+    var offset = container.getBoundingClientRect();
+    var rect = el.getBoundingClientRect();
+
+    return {
+        top: rect.top - offset.top,
+        left: rect.left - offset.left,
+        height: el.scrollHeight,
+        width: el.scrollWidth
+    };
+}
+
+
+function setCoords(el, coords) {
+    el.style.setProperty('top', `${coords.top}px`, 'important');
+    el.style.setProperty('left', `${coords.left}px`, 'important');
+    el.style.setProperty('height', `${coords.height}px`, 'important');
+    el.style.setProperty('width', `${coords.width}px`, 'important');
+}
+
+function contains(rect1, rect2) {
+  return (
+    (rect2.right <= rect1.right) &&
+    (rect2.left >= rect1.left) &&
+    (rect2.top >= rect1.top) &&
+    (rect2.bottom <= rect1.bottom)
+  );
+}

--- a/src/utils/marks/marks.js
+++ b/src/utils/marks/marks.js
@@ -184,11 +184,24 @@ export class Underline extends Highlight {
         for (var i = 0, len = filtered.length; i < len; i++) {
             var r = filtered[i];
 
+            var rect = svg.createElement('rect');
+            rect.setAttribute('x', r.left - offset.left + container.left);
+            rect.setAttribute('y', r.top - offset.top + container.top);
+            rect.setAttribute('height', r.height);
+            rect.setAttribute('width', r.width);
+            rect.setAttribute('fill', 'none');
+
             var line = svg.createElement('line');
             line.setAttribute('x1', r.left - offset.left + container.left);
             line.setAttribute('x2', r.left - offset.left + container.left + r.width);
             line.setAttribute('y1', r.top - offset.top + container.top + r.height - 1);
             line.setAttribute('y2', r.top - offset.top + container.top + r.height - 1);
+
+            line.setAttribute('stroke-width', 1);
+            line.setAttribute('stroke', 'black'); //TODO: match text color?
+            line.setAttribute('stroke-linecap', 'square');
+
+            docFrag.appendChild(rect);
 
             docFrag.appendChild(line);
         }

--- a/src/utils/marks/svg.js
+++ b/src/utils/marks/svg.js
@@ -1,0 +1,7 @@
+export function createElement(name) {
+    return document.createElementNS('http://www.w3.org/2000/svg', name);
+}
+
+export default {
+    createElement: createElement
+};


### PR DESCRIPTION
- Copies from source files from `marks-pane` library to `utils` so that we can easily modify them
- Filters out full-paragraph highlight SVGs that get added when highlighting/underlining more than 2 paragraphs