### PR TITLE
Use snap settings to determine swipe distance

### DIFF
--- a/examples/swipe.html
+++ b/examples/swipe.html
@@ -41,7 +41,11 @@
       flow: "paginated",
       width: "100%",
       height: "100%",
-      snap: true
+      snap: {
+        duration: 80,
+        minVelocity: 0.3,
+        minDistance: 10,
+      },
     });
 
     ''

--- a/src/managers/helpers/snap.js
+++ b/src/managers/helpers/snap.js
@@ -260,11 +260,20 @@ class Snap {
   snap(howMany = 0) {
     const left = this.scrollLeft;
     const snapWidth = this.layout.pageWidth * this.layout.divisor;
-    let snapTo = Math.round(left / snapWidth) * snapWidth;
-
-    // if (howMany) {
-    //   snapTo += (howMany * snapWidth);
-    // }
+    
+    // Get page number to snap to based on if we're going one page forward or backward
+    // If howMany = 0 (i.e. valid swipe was not detected),
+    // snap to current or prev/next page based on scroll distance
+    let pageToSnapTo;
+    if (howMany > 0) {
+      pageToSnapTo = Math.floor(left / snapWidth) + howMany;
+    } else if (howMany < 0) {
+      pageToSnapTo = Math.ceil(left / snapWidth) + howMany;
+    } else {
+      pageToSnapTo = Math.round(left / snapWidth);
+    }
+    
+    let snapTo = pageToSnapTo * snapWidth;
 
     return this.smoothScrollTo(snapTo);
   }


### PR DESCRIPTION
## What this does
- Makes sure the snap settings (ex. `minVelocity` and `minDistance`) determine the swipe detection and which position to snap tp

## How to test
- `npm start` and go to http://localhost:8088/examples/swipe.html 
- Make sure swipe detection feels good and is adjustable via the settings in `swipe.html` 