### PR TITLE
Fix multi paragraph highlighting

### DIFF
--- a/src/utils/marks/marks.js
+++ b/src/utils/marks/marks.js
@@ -98,22 +98,13 @@ export class Mark {
         const stringRectsSet = new Set(stringRects);
         const rectsSet = Array.from(stringRectsSet).map((sr) => JSON.parse(sr));
 
-        let filteredRects = [];
-        for (let i = 0; i < rectsSet.length; i++) {
-            const curRect = rectsSet[i];
-            let shouldPush = true;
-            for (let j = 0; j < rectsSet.length; j++) {
-                if (curRect !== rectsSet[j] && contains(curRect, rectsSet[j])) {
-                    shouldPush = false;
-                    break;
-                }
+        return rectsSet.reduce((filteredRects, curRect) => {
+            const shouldNotPush = rectsSet.some((item) => curRect !== item && contains(curRect, item));
+            if (!shouldNotPush) {
+              filteredRects.push(curRect);
             }
-            if (shouldPush) {
-                filteredRects.push(curRect);
-            }
-        }
-
-        return filteredRects;
+            return filteredRects;
+          }, []);
     }
 }
 

--- a/src/utils/marks/marks.js
+++ b/src/utils/marks/marks.js
@@ -92,10 +92,28 @@ export class Mark {
         if (!this.range) {
             return [];
         }
+
         const rects = Array.from(this.range.getClientRects());
         const stringRects = rects.map((r) => JSON.stringify(r));
-        const setRects = new Set(stringRects);
-        return Array.from(setRects).map((sr) => JSON.parse(sr));
+        const stringRectsSet = new Set(stringRects);
+        const rectsSet = Array.from(stringRectsSet).map((sr) => JSON.parse(sr));
+
+        let filteredRects = [];
+        for (let i = 0; i < rectsSet.length; i++) {
+            const curRect = rectsSet[i];
+            let shouldPush = true;
+            for (let j = 0; j < rectsSet.length; j++) {
+                if (curRect !== rectsSet[j] && contains(curRect, rectsSet[j])) {
+                    shouldPush = false;
+                    break;
+                }
+            }
+            if (shouldPush) {
+                filteredRects.push(curRect);
+            }
+        }
+
+        return filteredRects;
     }
 }
 


### PR DESCRIPTION
## What this does
Make sure child elements get highlighted _and_ filter out any SVG rects contain existing rects.

## How to test
- Open http://localhost:8088/examples/highlights.html with a book that has italics 
- Make sure you can highlight across 3+ paragraphs without double highlighting
- Make sure you can highlight italics within a sentence