### PR TITLE
[Bug] Fixes rendition `removed` event not calling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs",
-  "version": "0.3.93",
+  "version": "0.3.94",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -484,6 +484,7 @@ class ContinuousViewManager extends DefaultViewManager {
 		var bounds = view.bounds();
 
 		this.views.remove(view);
+		this.emit(EVENTS.MANAGERS.REMOVED, view.section, view);
 		
 		if(above) {
 			if (this.settings.axis === "vertical") {

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -484,7 +484,7 @@ class ContinuousViewManager extends DefaultViewManager {
 		var bounds = view.bounds();
 
 		this.views.remove(view);
-		this.emit(EVENTS.MANAGERS.REMOVED, view.section, view);
+		this.emit(EVENTS.MANAGERS.REMOVED, view);
 		
 		if(above) {
 			if (this.settings.axis === "vertical") {

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -483,6 +483,7 @@ class ContinuousViewManager extends DefaultViewManager {
 
 		var bounds = view.bounds();
 
+		this.emit(EVENTS.MANAGERS.BEFORE_REMOVED, view);
 		this.views.remove(view);
 		this.emit(EVENTS.MANAGERS.REMOVED, view);
 		

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -484,26 +484,24 @@ class ContinuousViewManager extends DefaultViewManager {
 		var bounds = view.bounds();
 
 		this.emit(EVENTS.MANAGERS.BEFORE_REMOVED, view);
-		requestAnimationFrame(() => {
-			this.views.remove(view);
-			this.emit(EVENTS.MANAGERS.REMOVED, view);
-			
-			if(above) {
-				if (this.settings.axis === "vertical") {
-					this.scrollTo(0, prevTop - bounds.height, true);
-				} else {
-					if(this.settings.direction === 'rtl') {
-						if (!this.settings.fullsize) {
-							this.scrollTo(prevLeft, 0, true);
-						} else {
-							this.scrollTo(prevLeft + Math.floor(bounds.width), 0, true);
-						}
+		this.views.remove(view);
+		this.emit(EVENTS.MANAGERS.REMOVED, view);
+		
+		if(above) {
+			if (this.settings.axis === "vertical") {
+				this.scrollTo(0, prevTop - bounds.height, true);
+			} else {
+				if(this.settings.direction === 'rtl') {
+					if (!this.settings.fullsize) {
+						this.scrollTo(prevLeft, 0, true);
 					} else {
-						this.scrollTo(prevLeft - Math.floor(bounds.width), 0, true);
+						this.scrollTo(prevLeft + Math.floor(bounds.width), 0, true);
 					}
+				} else {
+					this.scrollTo(prevLeft - Math.floor(bounds.width), 0, true);
 				}
 			}
-		})
+		}
 
 	}
 

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -484,7 +484,6 @@ class ContinuousViewManager extends DefaultViewManager {
 		var bounds = view.bounds();
 
 		this.views.remove(view);
-		console.log('remove view')
 		this.emit(EVENTS.MANAGERS.REMOVED, view);
 		
 		if(above) {

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -484,6 +484,7 @@ class ContinuousViewManager extends DefaultViewManager {
 		var bounds = view.bounds();
 
 		this.views.remove(view);
+		console.log('remove view')
 		this.emit(EVENTS.MANAGERS.REMOVED, view);
 		
 		if(above) {

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -484,24 +484,26 @@ class ContinuousViewManager extends DefaultViewManager {
 		var bounds = view.bounds();
 
 		this.emit(EVENTS.MANAGERS.BEFORE_REMOVED, view);
-		this.views.remove(view);
-		this.emit(EVENTS.MANAGERS.REMOVED, view);
-		
-		if(above) {
-			if (this.settings.axis === "vertical") {
-				this.scrollTo(0, prevTop - bounds.height, true);
-			} else {
-				if(this.settings.direction === 'rtl') {
-					if (!this.settings.fullsize) {
-						this.scrollTo(prevLeft, 0, true);
-					} else {
-						this.scrollTo(prevLeft + Math.floor(bounds.width), 0, true);
-					}
+		requestAnimationFrame(() => {
+			this.views.remove(view);
+			this.emit(EVENTS.MANAGERS.REMOVED, view);
+			
+			if(above) {
+				if (this.settings.axis === "vertical") {
+					this.scrollTo(0, prevTop - bounds.height, true);
 				} else {
-					this.scrollTo(prevLeft - Math.floor(bounds.width), 0, true);
+					if(this.settings.direction === 'rtl') {
+						if (!this.settings.fullsize) {
+							this.scrollTo(prevLeft, 0, true);
+						} else {
+							this.scrollTo(prevLeft + Math.floor(bounds.width), 0, true);
+						}
+					} else {
+						this.scrollTo(prevLeft - Math.floor(bounds.width), 0, true);
+					}
 				}
 			}
-		}
+		})
 
 	}
 

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -245,6 +245,7 @@ class Rendition {
 
 		// Listen for displayed views
 		this.manager.on(EVENTS.MANAGERS.ADDED, this.afterDisplayed.bind(this));
+		this.manager.on(EVENTS.MANAGERS.BEFORE_REMOVED, this.beforeRemoved.bind(this));
 		this.manager.on(EVENTS.MANAGERS.REMOVED, this.afterRemoved.bind(this));
 
 		// Listen for resizing
@@ -437,6 +438,22 @@ class Rendition {
 				}
 			});
 
+	}
+
+	/**
+	 * Report what will be removed
+	 * @private
+	 * @param  {*} view
+	 */
+	beforeRemoved(view){
+		/**
+		 * Emit that a section is about to be removed
+		 * @event removed
+		 * @param {Section} section
+		 * @param {View} view
+		 * @memberof Rendition
+		 */
+		this.emit(EVENTS.RENDITION.BEFORE_REMOVED, view.section, view);
 	}
 
 	/**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -24,6 +24,7 @@ export const EVENTS = {
     ADDED : "added",
     SCROLL : "scroll",
     SCROLLED : "scrolled",
+    BEFORE_REMOVED: "beforeremoved",
     REMOVED : "removed",
   },
   VIEWS : {
@@ -43,6 +44,7 @@ export const EVENTS = {
     DISPLAYED : "displayed",
     DISPLAY_ERROR : "displayerror",
     RENDERED : "rendered",
+    BEFORE_REMOVED : "beforeremoved",
     REMOVED : "removed",
     RESIZED : "resized",
     ORIENTATION_CHANGE : "orientationchange",


### PR DESCRIPTION
## What This Does

- Updates the continuous manager to emit the `removed` event when a view is removed

## How to Test

1. Add the dependency to your local branch (or checkout https://github.com/Upstatement/threadable_api/pull/913 and `yarn install`)
2. Add the following code to the `initEpub` method:
```
rendition.on('removed', () => console.log('removed'))
```
3. Scroll the page. Confirm the consoles appear as sections are removed