### PR TITLE
Fix: section not appending on resize

### DIFF
--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -101,6 +101,10 @@ class ContinuousViewManager extends DefaultViewManager {
 	}
 
 	afterResized(view){
+		this.q.enqueue(() => {
+			return this.check();
+		});
+		
 		this.emit(EVENTS.MANAGERS.RESIZE, view.section);
 	}
 


### PR DESCRIPTION
## What This Does
Makes sure continuous manager calls `check` on resize, which will calculate whether or not to append the next section.

## How to Test
- Update the `epubjs` package in `threadable_api` to point to this branch `github:Upstatement/epub.js#fix/content-not-appending`
- Open up a book in the web reader that has a cover image (DM me if you need one!)
- Make sure the book loads and is scrollable at different browser window sizes 